### PR TITLE
Making sentence generation timeout configurable

### DIFF
--- a/src/modules/corpus_generator.py
+++ b/src/modules/corpus_generator.py
@@ -5,7 +5,7 @@ from . import pd, os, sys, is_not_nan, time, re, datetime, np
 class SetsGenerator:
     def __init__(self, allow_free_structure_production, cognate_decimal, monolingual_only,
                  lang, lexicon_csv, structures_csv, input_dir=None, sim_results_dir=None, default_L2='en',
-                 include_ff=False):
+                 include_ff=False, generator_timeout=60):
         """
         :param allow_free_structure_production:
         """
@@ -36,6 +36,7 @@ class SetsGenerator:
         self.target_lang = [self.L1, L2] if not monolingual_only else [self.L1]
         # TODO: automate
         self.identifiability = ['pron', 'def', 'indef']
+        self.generator_timeout = generator_timeout
 
     def set_new_results_dir(self, results_dir):
         if os.path.isdir(results_dir):  # if this folder name exists already add a timestamp at the end
@@ -187,8 +188,8 @@ class SetsGenerator:
         remaining_structures = sentence_structures
         time_start = time.time()
         while len(remaining_structures):  # while loop needed because of the unique sentence restriction
-            if time.time() - time_start > 60:
-                sys.exit("The process timed out (limit: 60s). Remaining structures: "
+            if time.time() - time_start > self.generator_timeout:
+                sys.exit(f"The process timed out (limit: {self.generator_timeout}s). Remaining structures: "
                          f"{len(remaining_structures)} more structures: {set(remaining_structures)} "
                          f"(total: {len(sentence_structures)}).")
             remaining_structures, generated_pairs, max_cognate = self.structures_to_sentences(remaining_structures,

--- a/src/start_dual_path.py
+++ b/src/start_dual_path.py
@@ -112,6 +112,8 @@ if __name__ == "__main__":
                         help='Threshold for performance of simulations. Any simulations that performs has a percentage '
                              'of correct sentences < threshold are discarded')
     parser.add_argument('--config', default=False, help='Read arguments from file')
+    parser.add_argument('--generator_timeout', type=positive_int, default=60,
+                        help="Number of seconds before the sentence generation process times out, defaults to 60 seconds")
     """ !----------------------------------- boolean arguments -----------------------------------! """
     parser.add_argument('--prodrop', dest='prodrop', action='store_true', help='Indicates that it is a pro-drop lang')
     parser.set_defaults(prodrop=False)
@@ -248,7 +250,8 @@ if __name__ == "__main__":
                      f"and {args.structures} (structures)")
         input_sets = SetsGenerator(input_dir=input_dir, lang=args.lang, monolingual_only=args.monolingual,
                                    cognate_decimal=args.cognate_decimal_fraction, lexicon_csv=args.lexicon,
-                                   structures_csv=args.structures, allow_free_structure_production=args.free_pos)
+                                   structures_csv=args.structures, allow_free_structure_production=args.free_pos,
+                                  generator_timeout=args.generator_timeout)
         # I had issues with joblib installation on Ubuntu 16.04.6 LTS
         # If prefer="threads", deepcopy input sets. -1 means that all CPUs will be used
         # Parallel(n_jobs=-1)(delayed(create_input_for_simulation)(sim) for sim in simulation_range)


### PR DESCRIPTION
Larger training sets need a longer timeout to avoid unnecessary errors.